### PR TITLE
replace picamera with cv

### DIFF
--- a/camera.py
+++ b/camera.py
@@ -3,7 +3,6 @@
 #Desc: This scrtipt script..
 
 import cv2 as cv
-from imutils.video.pivideostream import PiVideoStream
 import imutils
 import time
 from datetime import datetime
@@ -11,24 +10,30 @@ import numpy as np
 
 class VideoCamera(object):
     def __init__(self, flip = False, file_type  = ".jpg", photo_string= "stream_photo"):
-        # self.vs = PiVideoStream(resolution=(1920, 1080), framerate=30).start()
-        self.vs = PiVideoStream().start()
+        self.vs = cv.VideoCapture(0)
         self.flip = flip # Flip frame vertically
         self.file_type = file_type # image type i.e. .jpg
         self.photo_string = photo_string # Name to save the photo
         time.sleep(2.0)
-
-    def __del__(self):
-        self.vs.stop()
 
     def flip_if_needed(self, frame):
         if self.flip:
             return np.flip(frame, 0)
         return frame
 
-    def get_frame(self):
-        frame = self.flip_if_needed(self.vs.read())
+    def get_frame(self) -> bytes:
+        ret, frame = self.vs.read()
+        if not ret:
+            print(f"failed to grab frame on read")
+            return bytes((0))
+                
         ret, jpeg = cv.imencode(self.file_type, frame)
+        if not ret:
+            print("failed to grab frame on encode")
+            return bytes((0))
+        
+        frame = self.flip_if_needed(frame)
+
         self.previous_frame = jpeg
         return jpeg.tobytes()
 


### PR DESCRIPTION
Since picamera is not supported on 64bit RaspbianOS, reading from the camera has to be done using an alternative library. Because this project already depends on cv2, this patch switches out picamera code for equivalent cv2 code.

This patch will fix issues #15, #30 and #31, since they are all picamera related.
It might also fix #32, (if that was not already fixed), because neither is QT4 ever used, nor does `libjasper-dev` seem to have any purpose. `libjapser-dev` was needed for cv2, but that might not be the case anymore, because the library is not installed on my Pi 4, though the program works fine.